### PR TITLE
Add methods to public API to detect if cursor at end of input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 # build tools
 /node_modules
-package-lock.json
-/build
 
 # dist
 /mathquill-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # build tools
 /node_modules
+package-lock.json
+/build
 
 # dist
 /mathquill-*.tgz

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -192,6 +192,12 @@ function getInterface(v) {
     };
     _.moveToLeftEnd = function() { return this.moveToDirEnd(L); };
     _.moveToRightEnd = function() { return this.moveToDirEnd(R); };
+    _.cursorAtLeftEnd = function () {
+      return this.__controller.cursor[L] === 0;
+    };
+    _.cursorAtRightEnd = function () {
+      return this.__controller.cursor[R] === 0;
+    };
 
     _.keystroke = function(keys) {
       var keys = keys.replace(/^\s+|\s+$/g, '').split(/\s+/);

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -152,16 +152,22 @@ suite('Public API', function() {
       assert.equal(mq.text(), '*2*3***4');
     });
 
-    test('.moveToDirEnd(dir)', function() {
-      mq.latex('a x^2 + b x + c = 0');
-      assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
+    test(".moveToDirEnd(dir)", function () {
+      mq.latex("a x^2 + b x + c = 0");
+      assert.equal(mq.__controller.cursor[L].ctrlSeq, "0");
       assert.equal(mq.__controller.cursor[R], 0);
+      assert.ok(mq.cursorAtRightEnd());
+      assert.ok(!mq.cursorAtLeftEnd());
       mq.moveToLeftEnd();
       assert.equal(mq.__controller.cursor[L], 0);
-      assert.equal(mq.__controller.cursor[R].ctrlSeq, 'a');
+      assert.equal(mq.__controller.cursor[R].ctrlSeq, "a");
+      assert.ok(mq.cursorAtLeftEnd());
+      assert.ok(!mq.cursorAtRightEnd());
       mq.moveToRightEnd();
-      assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
+      assert.equal(mq.__controller.cursor[L].ctrlSeq, "0");
       assert.equal(mq.__controller.cursor[R], 0);
+      assert.ok(mq.cursorAtRightEnd());
+      assert.ok(!mq.cursorAtLeftEnd());
     });
   });
 

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -152,19 +152,19 @@ suite('Public API', function() {
       assert.equal(mq.text(), '*2*3***4');
     });
 
-    test(".moveToDirEnd(dir)", function () {
-      mq.latex("a x^2 + b x + c = 0");
-      assert.equal(mq.__controller.cursor[L].ctrlSeq, "0");
+    test('.moveToDirEnd(dir)', function() {
+      mq.latex('a x^2 + b x + c = 0');
+      assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
       assert.equal(mq.__controller.cursor[R], 0);
       assert.ok(mq.cursorAtRightEnd());
       assert.ok(!mq.cursorAtLeftEnd());
       mq.moveToLeftEnd();
       assert.equal(mq.__controller.cursor[L], 0);
-      assert.equal(mq.__controller.cursor[R].ctrlSeq, "a");
+      assert.equal(mq.__controller.cursor[R].ctrlSeq, 'a');
       assert.ok(mq.cursorAtLeftEnd());
       assert.ok(!mq.cursorAtRightEnd());
       mq.moveToRightEnd();
-      assert.equal(mq.__controller.cursor[L].ctrlSeq, "0");
+      assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
       assert.equal(mq.__controller.cursor[R], 0);
       assert.ok(mq.cursorAtRightEnd());
       assert.ok(!mq.cursorAtLeftEnd());


### PR DESCRIPTION
Adds two methods to public API:
`cursorAtRightEnd`
`cursorAtLeftEnd`

We need these for our Khanmigo math input nodes to operate more like a singular text input.

Unfortunately, since `mathQuill`'s input is more like a linked list than an array like a text area, we cannot easily add typical fields: `selectionStart`, `selectionEnd`, or an `onSelect` event. The indices wouldn't be useful without some complex traversal logic.

For our purposes, we simply need to know whether the cursor is at one end or another, and MathQuill has simple ways to discover this.