### PR TITLE
Expose controller

### DIFF
--- a/build/mathquill.d.ts
+++ b/build/mathquill.d.ts
@@ -53,6 +53,7 @@ declare namespace MathQuill {
         endIndex: number;
       };
       cursor(): any; // TODO(LC-1659): Cursor interface
+      controller(): any; // ^^ Likewise
 
       select: () => EditableMathQuill;
       moveToRightEnd: () => EditableMathQuill;

--- a/build/mathquill.d.ts
+++ b/build/mathquill.d.ts
@@ -9,7 +9,10 @@ declare namespace MathQuill {
   namespace v3 {
     type HandlersWithDirection = v1.HandlersWithDirection;
     type HandlersWithoutDirection = v1.HandlersWithoutDirection;
-    type HandlerOptions = v1.HandlerOptions<BaseMathQuill>;
+    // The following should probably take a type parameter, but that would require
+    //   a bit of a refactor. Since we only deal with EditableMathQuill, we'll
+    //   just use that for now.
+    type HandlerOptions = v1.HandlerOptions<Partial<EditableMathQuill>>;
     type EmbedOptions = v1.EmbedOptions;
     type EmbedOptionsData = v1.EmbedOptionsData;
 
@@ -33,20 +36,7 @@ declare namespace MathQuill {
       text(): string;
     }
 
-    interface EditableMathQuill {
-      id: number;
-      data: { [key: string]: any };
-      revert: () => HTMLElement;
-      config(opts: Config): EditableMathQuill;
-      latex(latex: string): EditableMathQuill;
-      latex(): string;
-      reflow: () => void;
-      el: () => HTMLElement;
-      getAriaLabel(): string;
-      setAriaLabel(str: string): EditableMathQuill;
-      html: () => string;
-      mathspeak: () => string;
-      text(): string;
+    interface EditableMathQuill extends BaseMathQuill {
       selection(): {
         latex: string;
         startIndex: number;

--- a/build/mathquill.js
+++ b/build/mathquill.js
@@ -2342,6 +2342,9 @@ function getInterface(v) {
     AbstractMathQuill.prototype.cursor = function () {
       return this.__controller.cursor;
     };
+    AbstractMathQuill.prototype.controller = function () {
+      return this.__controller;
+    };
     return AbstractMathQuill;
   })(Progenote);
   var EditableField = /** @class */ (function (_super) {

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -55,6 +55,7 @@ declare namespace MathQuill {
         endIndex: number;
       };
       cursor(): any; // TODO(LC-1659): Cursor interface
+      controller(): any; // ^^ Likewise
 
       select: () => EditableMathQuill;
       moveToRightEnd: () => EditableMathQuill;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -11,7 +11,10 @@ declare namespace MathQuill {
   namespace v3 {
     type HandlersWithDirection = v1.HandlersWithDirection;
     type HandlersWithoutDirection = v1.HandlersWithoutDirection;
-    type HandlerOptions = v1.HandlerOptions<BaseMathQuill>;
+    // The following should probably take a type parameter, but that would require
+    //   a bit of a refactor. Since we only deal with EditableMathQuill, we'll
+    //   just use that for now.
+    type HandlerOptions = v1.HandlerOptions<Partial<EditableMathQuill>>;
     type EmbedOptions = v1.EmbedOptions;
     type EmbedOptionsData = v1.EmbedOptionsData;
 
@@ -35,20 +38,7 @@ declare namespace MathQuill {
       text(): string;
     }
 
-    interface EditableMathQuill {
-      id: number;
-      data: { [key: string]: any };
-      revert: () => HTMLElement;
-      config(opts: Config): EditableMathQuill;
-      latex(latex: string): EditableMathQuill;
-      latex(): string;
-      reflow: () => void;
-      el: () => HTMLElement;
-      getAriaLabel(): string;
-      setAriaLabel(str: string): EditableMathQuill;
-      html: () => string;
-      mathspeak: () => string;
-      text(): string;
+    interface EditableMathQuill extends BaseMathQuill {
       selection(): {
         latex: string;
         startIndex: number;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -349,6 +349,9 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
     cursor() {
       return this.__controller.cursor;
     }
+    controller() {
+      return this.__controller;
+    }
   }
 
   abstract class EditableField


### PR DESCRIPTION
Exposing the controller to provide better control over the mathquill instance.

We already access it in Perseus, but we do so in a hacky way. Let's make it official.