### PR TITLE
Remove cursor() and controller() from MathQuill namespace in mathquill.d.ts

### DIFF
--- a/build/mathquill.d.ts
+++ b/build/mathquill.d.ts
@@ -53,8 +53,6 @@ declare namespace MathQuill {
         startIndex: number;
         endIndex: number;
       };
-      cursor(): any; // TODO(LC-1659): Cursor interface
-      controller(): any; // ^^ Likewise
 
       select: () => EditableMathQuill;
       moveToRightEnd: () => EditableMathQuill;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -41,8 +41,6 @@ declare namespace MathQuill {
         startIndex: number;
         endIndex: number;
       };
-      cursor(): any; // TODO(LC-1659): Cursor interface
-      controller(): any; // ^^ Likewise
 
       select: () => EditableMathQuill;
       moveToRightEnd: () => EditableMathQuill;


### PR DESCRIPTION
## Summary:
There was a lot of weirdness with trying to add the
types for cursor() and controller() here. It either
breaks all the types in MathQuill, or it breaks all
the types in Perseus. Alternatively, we were going
to [add the types in the build/ folder but not in src/](https://github.com/Khan/mathquill/pull/19),
but then we wouldn't be able to keep those two
mathquill.d.ts files in sync.

The new approach we're trying is to go back to what
this was before in mathquill - not having these types
defined here - and instead, define these types on top
in Perseus. This should remove all the type errors
and still allow us to use the types the way we want.

Issue: https://khanacademy.atlassian.net/browse/LC-1659

## Test plan:
`make lint`