### PR TITLE
Make font references relative so they can be processed properly!

### DIFF
--- a/build/mathquill.css
+++ b/build/mathquill.css
@@ -29,8 +29,8 @@
 }
 @font-face {
   font-family: Symbola;
-  src: url(/fonts/Symbola.eot);
-  src: local('Symbola Regular'), local('Symbola'), url(/fonts/Symbola.woff2) format('woff2'), url(/fonts/Symbola.woff) format('woff'), url(/fonts/Symbola.ttf) format('truetype'), url(/fonts/Symbola.otf) format('opentype'), url(/fonts/Symbola.svg#Symbola) format('svg');
+  src: url(fonts/Symbola.eot);
+  src: local('Symbola Regular'), local('Symbola'), url(fonts/Symbola.woff2) format('woff2'), url(fonts/Symbola.woff) format('woff'), url(fonts/Symbola.ttf) format('truetype'), url(fonts/Symbola.otf) format('opentype'), url(fonts/Symbola.svg#Symbola) format('svg');
 }
 .mq-editable-field {
   display: -moz-inline-box;

--- a/src/css/font.less
+++ b/src/css/font.less
@@ -9,18 +9,18 @@
 
 @basic:~ "";
 .font-srcs() when not (@basic) {
-  src: url(/fonts/Symbola.eot);
+  src: url(fonts/Symbola.eot);
   src: local('Symbola Regular'), local('Symbola'),
-    url(/fonts/Symbola.woff2) format('woff2'),
-    url(/fonts/Symbola.woff) format('woff'),
-    url(/fonts/Symbola.ttf) format('truetype'),
-    url(/fonts/Symbola.otf) format('opentype'),
-    url(/fonts/Symbola.svg#Symbola) format('svg');
+    url(fonts/Symbola.woff2) format('woff2'),
+    url(fonts/Symbola.woff) format('woff'),
+    url(fonts/Symbola.ttf) format('truetype'),
+    url(fonts/Symbola.otf) format('opentype'),
+    url(fonts/Symbola.svg#Symbola) format('svg');
 }
 .font-srcs() when (@basic) {
-  src: url(/fonts/Symbola-basic.eot);
+  src: url(fonts/Symbola-basic.eot);
   src: local('Symbola Regular'), local('Symbola'),
-    url(/fonts/Symbola-basic.woff2) format('woff2'),
-    url(/fonts/Symbola-basic.woff) format('woff'),
-    url(/fonts/Symbola-basic.ttf) format('truetype');
+    url(fonts/Symbola-basic.woff2) format('woff2'),
+    url(fonts/Symbola-basic.woff) format('woff'),
+    url(fonts/Symbola-basic.ttf) format('truetype');
 }


### PR DESCRIPTION
## Summary:

On Friday I was playing around with optimizing our tooling in Perseus. One thing that came up again was that the font paths in Mathquill are absolute paths `/fonts/...`. 

This is incorrect and makes bundling anything that depends on mathquill difficult (because the bundler can never resolve the Symbola font paths without alot of help... and even then it's tricky). 

So, this PR adjusts the font paths to be relative to the CSS file. This makes it so bundlers can find the font files during bundle time and then copy the font files to their production destination as needed.

Issue: LC-375

## Test plan:

I built mathquill and then did `npm pack` to get a tarball.  I then installed this into Perseus' `@khanacademy/math-input` package and verified that the bundler found and could process the font files.